### PR TITLE
Change bower version to a valid semver

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "flot-spline",
-  "version": "0.1",
+  "version": "0.0.1",
   "homepage": "https://github.com/JohnPozy/flot-spline",
   "authors": [
     "Alex Bardas < alex.bardas@gmail.com >"


### PR DESCRIPTION
Some tools of mine are puking on the version number since it isn't valid according to semver (http://semver.org/)
